### PR TITLE
fix：定时任务启动后未关闭死连接

### DIFF
--- a/back_end/saolei/monitor/management/commands/runapschedulermonitor.py
+++ b/back_end/saolei/monitor/management/commands/runapschedulermonitor.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 # 5秒执行一次。定时计算刷新监视状态量。服务器io
+@util.close_old_connections
 def refresh_state_always():
     net_io = psutil.net_io_counters()
     net_io_sent_old = cache.get("io_s_old") if cache.exists("io_s_old") else "0.0"

--- a/back_end/saolei/userprofile/management/commands/runapscheduleruserprofile.py
+++ b/back_end/saolei/userprofile/management/commands/runapscheduleruserprofile.py
@@ -18,13 +18,13 @@ logger = logging.getLogger(__name__)
 # 定时任务文档
 # https://pypi.org/project/django-apscheduler/
 
-
+@util.close_old_connections
 def delete_overdue_emailverifyrecord():
     # 定时清除过期邮箱验证码（1小时过期）
     start = timezone.now() - timezone.timedelta(seconds=3600)
     EmailVerifyRecord.objects.filter(send_time__lt=start).delete()
 
-
+@util.close_old_connections
 def delete_overdue_captcha():
     # 定时清除过期图形验证码（15分钟过期）
     # start = timezone.now() - timezone.timedelta(seconds=900)

--- a/back_end/saolei/videomanager/management/commands/runapschedulervideomanager.py
+++ b/back_end/saolei/videomanager/management/commands/runapschedulervideomanager.py
@@ -30,6 +30,7 @@ def n_days_ago(time_str: str, n=7) -> bool:
 
 
 # 定时清除最新录像，直至剩下最近7天的或剩下不到100条
+@util.close_old_connections
 def delete_newest_queue():
     if cache.hlen("newest_queue") <= 100:
         return
@@ -46,12 +47,14 @@ def delete_newest_queue():
 
 
 # 定时清除7天以前冻结的录像
+@util.close_old_connections
 def delete_freezed_video():
     ddl = datetime.now(timezone.utc) - timedelta(days=7)
     VideoModel.objects.filter(upload_time__lt=ddl, state="b").delete()
 
 
 # 定时清除新闻
+@util.close_old_connections
 def delete_news_queue():
     # 此处经常只能执行一次后任务消失。尝试在线上环境捕获问题。
     logger.info("Starting delete_news_queue task")


### PR DESCRIPTION
用SHOW PROCESSLIST;命令检查可以看到，定时任务挂掉的原因是死链接占满mysql。默认的是8小时。加上@util.close_old_connections装饰器，执行完后自动关闭与MySQL连接。